### PR TITLE
Fixed bug previous button not working

### DIFF
--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -244,7 +244,6 @@ export const changeSlide = (spec, options) => {
   var indexOffset, previousInt, slideOffset, unevenOffset, targetSlide;
   const {
     slidesToScroll,
-    slidesToShow,
     slideCount,
     currentSlide,
     lazyLoad,
@@ -255,7 +254,7 @@ export const changeSlide = (spec, options) => {
 
   if (options.message === "previous") {
     slideOffset =
-      indexOffset === 0 ? slidesToScroll : slidesToShow - indexOffset;
+      indexOffset === 0 ? slidesToScroll : slidesToScroll - indexOffset;
     targetSlide = currentSlide - slideOffset;
     if (lazyLoad && !infinite) {
       previousInt = currentSlide - slideOffset;


### PR DESCRIPTION
The slidesToShow variable is not even necessary here, so I removed that too.

I found this bug by creating a carousel with the following props:
- variableWidth: true
- infinite: false
- slidesToScroll: 3

I had 18 slides. When I clicked the next button for the last time, only the last slide showed, which is OK. But from then on the previous button stopped working. I looked up the source and found the bug. Fixed it and the problem went away.